### PR TITLE
Fix/logger sync fail on linux

### DIFF
--- a/cmd/comment/api.go
+++ b/cmd/comment/api.go
@@ -48,11 +48,7 @@ func runAPI(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			log.Fatal("failed to sync logger", err.Error())
-		}
-	}()
+	defer logger.Sync()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/comment/api.go
+++ b/cmd/comment/api.go
@@ -48,7 +48,9 @@ func runAPI(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer logger.Sync()
+	defer func() {
+		_ = logger.Sync()
+	}()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/comment/gateway.go
+++ b/cmd/comment/gateway.go
@@ -41,11 +41,7 @@ func runGateway(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			log.Fatal("failed to sync logger", err.Error())
-		}
-	}()
+	defer logger.Sync()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/comment/gateway.go
+++ b/cmd/comment/gateway.go
@@ -41,7 +41,9 @@ func runGateway(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer logger.Sync()
+	defer func() {
+		_ = logger.Sync()
+	}()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/video/api.go
+++ b/cmd/video/api.go
@@ -52,11 +52,7 @@ func runAPI(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			log.Fatal("failed to sync logger", err.Error())
-		}
-	}()
+	defer logger.Sync()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/video/api.go
+++ b/cmd/video/api.go
@@ -52,7 +52,9 @@ func runAPI(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer logger.Sync()
+	defer func() {
+		_ = logger.Sync()
+	}()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/video/gateway.go
+++ b/cmd/video/gateway.go
@@ -43,11 +43,7 @@ func runGateway(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			log.Fatal("failed to sync logger", err.Error())
-		}
-	}()
+	defer logger.Sync()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/video/gateway.go
+++ b/cmd/video/gateway.go
@@ -43,7 +43,9 @@ func runGateway(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer logger.Sync()
+	defer func() {
+		_ = logger.Sync()
+	}()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/video/stream.go
+++ b/cmd/video/stream.go
@@ -41,7 +41,9 @@ func runStream(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer logger.Sync()
+	defer func() {
+		_ = logger.Sync()
+	}()
 
 	ctx = logger.WithContext(ctx)
 

--- a/cmd/video/stream.go
+++ b/cmd/video/stream.go
@@ -41,11 +41,7 @@ func runStream(_ *cobra.Command, _ []string) error {
 	}
 
 	logger := logkit.NewLogger(&args.LoggerConfig)
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			log.Fatal("failed to sync logger", err.Error())
-		}
-	}()
+	defer logger.Sync()
 
 	ctx = logger.WithContext(ctx)
 


### PR DESCRIPTION
https://github.com/uber-go/zap/issues/328

Zap logger sync fail on linux. But it is ok to ignore the error.